### PR TITLE
Support cf tasks which where cf.instance.index is null

### DIFF
--- a/src/main/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfiguration.java
+++ b/src/main/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.cloudfoundry.metrics;
 
+import com.netflix.frigga.Names;
+import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -25,10 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
-
-import com.netflix.frigga.Names;
-
-import io.micrometer.core.instrument.config.MeterFilter;
 
 @AutoConfigureBefore(MetricsAutoConfiguration.class)
 @ConditionalOnClass(MeterFilter.class)

--- a/src/main/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfiguration.java
+++ b/src/main/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.cloudfoundry.metrics;
 
-import com.netflix.frigga.Names;
-import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,6 +25,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+
+import com.netflix.frigga.Names;
+
+import io.micrometer.core.instrument.config.MeterFilter;
 
 @AutoConfigureBefore(MetricsAutoConfiguration.class)
 @ConditionalOnClass(MeterFilter.class)
@@ -83,7 +85,7 @@ class CloudFoundryTagsMeterFilterAutoConfiguration {
             return instanceIndex;
         }
 
-        return environment.getRequiredProperty("cf.instance.index");
+        return environment.getProperty("cf.instance.index");
     }
 
     private Names getNames(Environment environment) {

--- a/src/test/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfigurationTest.java
+++ b/src/test/java/org/cloudfoundry/metrics/CloudFoundryTagsMeterFilterAutoConfigurationTest.java
@@ -74,6 +74,25 @@ final class CloudFoundryTagsMeterFilterAutoConfigurationTest {
             Tag.of("cf.version", "42")
         );
     }
+    
+    @Test
+    void defaultsWithoutInstanceIndex() {
+        Meter.Id id = new CloudFoundryTagsMeterFilterAutoConfiguration().meterFilter(new MockEnvironment()
+            .withProperty("vcap.application.cf_api", "test-cf-api")
+            .withProperty("vcap.application.application_name", "test.application-r042")
+            .withProperty("vcap.application.organization_name", "test-organization-name")
+            .withProperty("vcap.application.space_name", "test-space-name")
+        ).map(new Meter.Id("test", Tags.empty(), null, null, Meter.Type.GAUGE));
+
+        assertThat(id.getTags()).containsExactly(
+            Tag.of("cf.account", "test-cf-api"),
+            Tag.of("cf.application", "test.application"),
+            Tag.of("cf.cluster", "test.application-r042"),
+            Tag.of("cf.organization", "test-organization-name"),
+            Tag.of("cf.space", "test-space-name"),
+            Tag.of("cf.version", "42")
+        );
+    }    
 
     @Test
     void defaultsWithoutOrganizationName() {


### PR DESCRIPTION
After upgrading to buildpack v4.21 cf java applications which execute tasks via `cf run-task` fail to start because cf.instance.index property is not. 

This PR includes updates to not require cf.instance.index to be set as well adding test coverage for the use case where the cf instance index is null.

Fixes cloudfoundry/java-buildpack#747